### PR TITLE
refactor: make trumpet modern again

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "standard"
-  ]
-}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends: [standard]
+parser: babel-eslint

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,5 @@
-extends: [standard]
+extends:
+  - standard
 parser: babel-eslint
+plugins:
+  - html

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# node-trumpet2
+# trumpet
 
-[![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/gofunky/node-trumpet2/build/master?style=for-the-badge)](https://github.com/gofunky/node-trumpet2/actions)
-[![Codecov](https://img.shields.io/codecov/c/github/gofunky/node-trumpet2?style=for-the-badge)](https://codecov.io/gh/gofunky/node-trumpet2)
-[![Renovate Status](https://img.shields.io/badge/renovate-enabled-green?style=for-the-badge&logo=renovatebot&color=1a1f6c)](https://app.renovatebot.com/dashboard#github/gofunky/node-trumpet2)
+[![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/gofunky/trumpet/build/master?style=for-the-badge)](https://github.com/gofunky/trumpet/actions)
+[![Codecov](https://img.shields.io/codecov/c/github/gofunky/trumpet?style=for-the-badge)](https://codecov.io/gh/gofunky/trumpet)
+[![Renovate Status](https://img.shields.io/badge/renovate-enabled-green?style=for-the-badge&logo=renovatebot&color=1a1f6c)](https://app.renovatebot.com/dashboard#github/gofunky/trumpet)
 [![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/npm/node-trumpet2?style=for-the-badge)](https://libraries.io/npm/node-trumpet2)
-[![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/node-trumpet2?style=for-the-badge)](https://snyk.io/test/github/gofunky/node-trumpet2)
+[![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/node-trumpet2?style=for-the-badge)](https://snyk.io/test/github/gofunky/trumpet)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-purple.svg?style=for-the-badge)](https://standardjs.com)
-[![CodeFactor](https://www.codefactor.io/repository/github/gofunky/node-trumpet2/badge?style=for-the-badge)](https://www.codefactor.io/repository/github/gofunky/node-trumpet2)
+[![CodeFactor](https://www.codefactor.io/repository/github/gofunky/trumpet/badge?style=for-the-badge)](https://www.codefactor.io/repository/github/gofunky/trumpet)
 [![node-current](https://img.shields.io/node/v/node-trumpet2?style=for-the-badge)](https://www.npmjs.com/package/node-trumpet2)
 [![NPM version](https://img.shields.io/npm/v/node-trumpet2?style=for-the-badge)](https://www.npmjs.com/package/node-trumpet2)
 [![NPM Downloads](https://img.shields.io/npm/dm/node-trumpet2?style=for-the-badge&color=ff69b4)](https://www.npmjs.com/package/node-trumpet2)
-[![GitHub License](https://img.shields.io/github/license/gofunky/node-trumpet2.svg?style=for-the-badge)](https://github.com/gofunky/node-trumpet2/blob/master/LICENSE)
-[![GitHub last commit](https://img.shields.io/github/last-commit/gofunky/node-trumpet2.svg?style=for-the-badge&color=9cf)](https://github.com/gofunky/node-trumpet2/commits/master)
+[![GitHub License](https://img.shields.io/github/license/gofunky/trumpet.svg?style=for-the-badge)](https://github.com/gofunky/trumpet/blob/master/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/gofunky/trumpet.svg?style=for-the-badge&color=9cf)](https://github.com/gofunky/trumpet/commits/master)
 
 the maintained version of [trumpet](https://github.com/substack/node-trumpet)
 
@@ -19,7 +19,7 @@ the maintained version of [trumpet](https://github.com/substack/node-trumpet)
 
 With [npm](http://npmjs.org) do:
 
-    npm install node-trumpet2
+    npm install @gofunky/trumpet
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -3,23 +3,17 @@
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/gofunky/trumpet/build/master?style=for-the-badge)](https://github.com/gofunky/trumpet/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/gofunky/trumpet?style=for-the-badge)](https://codecov.io/gh/gofunky/trumpet)
 [![Renovate Status](https://img.shields.io/badge/renovate-enabled-green?style=for-the-badge&logo=renovatebot&color=1a1f6c)](https://app.renovatebot.com/dashboard#github/gofunky/trumpet)
-[![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/npm/node-trumpet2?style=for-the-badge)](https://libraries.io/npm/node-trumpet2)
-[![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/node-trumpet2?style=for-the-badge)](https://snyk.io/test/github/gofunky/trumpet)
+[![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/npm/@gofunky/trumpet?style=for-the-badge)](https://libraries.io/npm/@gofunky/trumpet)
+[![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/@gofunky/trumpet?style=for-the-badge)](https://snyk.io/test/github/gofunky/trumpet)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-purple.svg?style=for-the-badge)](https://standardjs.com)
 [![CodeFactor](https://www.codefactor.io/repository/github/gofunky/trumpet/badge?style=for-the-badge)](https://www.codefactor.io/repository/github/gofunky/trumpet)
-[![node-current](https://img.shields.io/node/v/node-trumpet2?style=for-the-badge)](https://www.npmjs.com/package/node-trumpet2)
-[![NPM version](https://img.shields.io/npm/v/node-trumpet2?style=for-the-badge)](https://www.npmjs.com/package/node-trumpet2)
-[![NPM Downloads](https://img.shields.io/npm/dm/node-trumpet2?style=for-the-badge&color=ff69b4)](https://www.npmjs.com/package/node-trumpet2)
+[![node-current](https://img.shields.io/node/v/@gofunky/trumpet?style=for-the-badge)](https://www.npmjs.com/package/@gofunky/trumpet)
+[![NPM version](https://img.shields.io/npm/v/@gofunky/trumpet?style=for-the-badge)](https://www.npmjs.com/package/@gofunky/trumpet)
+[![NPM Downloads](https://img.shields.io/npm/dm/@gofunky/trumpet?style=for-the-badge&color=ff69b4)](https://www.npmjs.com/package/@gofunky/trumpet)
 [![GitHub License](https://img.shields.io/github/license/gofunky/trumpet.svg?style=for-the-badge)](https://github.com/gofunky/trumpet/blob/master/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/gofunky/trumpet.svg?style=for-the-badge&color=9cf)](https://github.com/gofunky/trumpet/commits/master)
 
 the maintained version of [trumpet](https://github.com/substack/node-trumpet)
-
-## Install
-
-With [npm](http://npmjs.org) do:
-
-    npm install @gofunky/trumpet
 
 ## Examples
 
@@ -39,15 +33,15 @@ input html:
 code:
 
 ```js
-const trumpet = require('node-trumpet2');
-const tr = trumpet();
-tr.pipe(process.stdout);
+const trumpet = require('@gofunky/trumpet')
+const tr = trumpet()
+tr.pipe(process.stdout)
  
-const ws = tr.select('tbody').createWriteStream();
-ws.end('<tr><td>rawr</td></tr>');
+const ws = tr.select('tbody').createWriteStream()
+ws.end('<tr><td>rawr</td></tr>')
 
-const fs = require('fs');
-fs.createReadStream(__dirname + '/html/table.html').pipe(tr);
+const fs = require('fs')
+fs.createReadStream(__dirname + '/html/table.html').pipe(tr)
 ```
 
 output:
@@ -85,15 +79,15 @@ Input html:
 code:
 
 ```js
-const trumpet = require('node-trumpet2');
-const tr = trumpet();
+const trumpet = require('@gofunky/trumpet')
+const tr = trumpet()
 
-tr.selectAll('.b span', function (span) {
-    span.createReadStream().pipe(process.stdout);
-});
+tr.selectAll('.b span', (span) => {
+  span.createReadStream().pipe(process.stdout)
+})
 
-const fs = require('fs');
-fs.createReadStream(__dirname + '/html/read_all.html').pipe(tr);
+const fs = require('fs')
+fs.createReadStream(__dirname + '/html/read_all.html').pipe(tr)
 ```
 
 output:
@@ -121,29 +115,29 @@ input html:
 code:
 
 ```js
-const trumpet = require('node-trumpet2');
-const through = require('through2');
+const trumpet = require('@gofunky/trumpet')
+const through = require('through2')
 
-const tr = trumpet();
+const tr = trumpet()
 
 //select all element and apply transformation function to selections
-tr.selectAll('.x span', function (element) {
+tr.selectAll('.x span', (element) => {
+ 
     //define function to transform input
-    const upper = through(function (buf) {
-        this.queue(buf.toString().toUpperCase());
-    });
-
+    const upper = through((buf) => {
+      this.queue(String(buf).toUpperCase())
+    })
+    
     //create a read/write stream for selected selement
-    const estream = element.createStream();
-
+    const stream = element.createStream()
+    
     //stream the element's inner html to transformation function
     //then stream the transformed output back into the element stream
-    estream.pipe(upper).pipe(estream);
-});
+    stream.pipe(upper).pipe(stream)
 
 //stream in html to trumpet and stream processed output to stdout
-const fs = require('fs');
-fs.createReadStream(__dirname + '/html/uppercase.html').pipe(tr).pipe(process.stdout);
+const fs = require('fs')
+fs.createReadStream(__dirname + '/html/uppercase.html').pipe(tr).pipe(process.stdout)
 ```
 
 output:
@@ -163,39 +157,39 @@ output:
 ## Methods
 
 ```js
-const trumpet = require('node-trumpet2')
+const trumpet = require('@gofunky/trumpet')
 ```
 
-### const tr = trumpet(opts)
+### `const tr = trumpet(opts)`
 
 Create a new trumpet stream. This stream is readable and writable.
 Pipe an html stream into `tr` and get back a transformed html stream.
 
 Parse errors are emitted by `tr` in an `'error'` event.
 
-### const elem = tr.select(selector)
+### `const elem = tr.select(selector)`
 
 Return a result object `elem` for the first element matching `selector`.
 
-### tr.selectAll(selector, function (elem) {})
+### `tr.selectAll(selector, function (elem) {})`
 
 Get a result object `elem` for every element matching `selector`.
 
-### elem.getAttribute(name, cb)
+### `elem.getAttribute(name, cb)`
 
 When the selector for `elem` matches, query the case-insensitive attribute
 called `name` with `cb(value)`.
 
 Returns `elem`.
 
-### elem.getAttributes(name, cb)
+### `elem.getAttributes(name, cb)`
 
 Get all the elements in `cb(attributes)` as an object `attributes` with
 lower-case keys.
 
 Returns `elem`.
 
-### elem.setAttribute(name, value)
+### `elem.setAttribute(name, value)`
 
 When the selector for `elem` matches, replace the case-insensitive attribute
 called `name` with `value`.
@@ -204,47 +198,47 @@ If the attribute doesn't exist, it will be created in the output stream.
 
 Returns `elem`.
 
-### elem.removeAttribute(name)
+### `elem.removeAttribute(name)`
 
 When the selector for `elem` matches, remove the attribute called `name` if it
 exists.
 
 Returns `elem`.
 
-### elem.createReadStream(opts)
+### `elem.createReadStream(opts)`
 
 Create a new readable stream with the inner html content under `elem`.
 
 To use the outer html content instead of the inner, set `opts.outer` to `true`.
 
-### elem.createWriteStream(opts)
+### `elem.createWriteStream(opts)`
 
 Create a new write stream to replace the inner html content under `elem`.
 
 To use the outer html content instead of the inner, set `opts.outer` to `true`.
 
-### elem.createStream(opts)
+### `elem.createStream(opts)`
 
 Create a new readable writable stream that outputs the content under `elem` and
 replaces the content with the data written to it.
 
 To use the outer html content instead of the inner, set `opts.outer` to `true`.
 
-### tr.createStream(sel, opts)
+### `tr.createStream(sel, opts)`
 
 Short-hand for `tr.select(sel).createStream(opts)`.
 
-### tr.createReadStream(sel, opts)
+### `tr.createReadStream(sel, opts)`
 
 Short-hand for `tr.select(sel).createReadStream(opts)`.
 
-### tr.createWriteStream(sel, opts)
+### `tr.createWriteStream(sel, opts)`
 
 Short-hand for `tr.select(sel).createWriteStream(opts)`.
 
 ## Attributes
 
-### elem.name
+### `elem.name`
 
 The element name as a lower-case string. For example: `'div'`.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Parse errors are emitted by `tr` in an `'error'` event.
 
 Return a result object `elem` for the first element matching `selector`.
 
-### `tr.selectAll(selector, function (elem) {})`
+### `tr.selectAll(selector, (elem) => {})`
 
 Get a result object `elem` for every element matching `selector`.
 

--- a/example/delay.js
+++ b/example/delay.js
@@ -1,26 +1,21 @@
 const trumpet = require('../')
-const tr = trumpet()
 const through = require('through2')
+const fs = require('fs')
+
+const tr = trumpet()
 tr.pipe(process.stdout)
-
-tr.selectAll('.x span', function (span) {
+tr.selectAll('.x span', (span) => {
   const stream = span.createStream()
-  stream.pipe(through(write, end)).pipe(stream)
-
-  function write (buf) {
-    const self = this
-    setTimeout(function () {
-      self.queue(buf.toString().toUpperCase())
-    }, 100)
-  }
-
-  function end () {
-    const self = this
-    setTimeout(function () {
-      self.queue(null)
-    }, 100)
-  }
+  stream.pipe(through(
+    (buf) => {
+      setTimeout(() => {
+        this.queue(buf.toString().toUpperCase())
+      }, 100)
+    }, () => {
+      setTimeout(() => {
+        this.queue(null)
+      }, 100)
+    })).pipe(stream)
 })
 
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/uppercase.html`).pipe(tr)

--- a/example/delay.js
+++ b/example/delay.js
@@ -9,7 +9,7 @@ tr.selectAll('.x span', (span) => {
   stream.pipe(through(
     (buf) => {
       setTimeout(() => {
-        this.queue(buf.toString().toUpperCase())
+        this.queue(String(buf).toUpperCase())
       }, 100)
     }, () => {
       setTimeout(() => {

--- a/example/inline_coffee.js
+++ b/example/inline_coffee.js
@@ -8,7 +8,7 @@ const coffee = require('coffeescript')
 const coffeeStream = (() => {
   const output = through()
   const input = concat((body) => {
-    output.queue(coffee.compile(body.toString()))
+    output.queue(coffee.compile(String(body)))
     output.queue(null)
   })
   return duplexer(input, output)

--- a/example/inline_coffee.js
+++ b/example/inline_coffee.js
@@ -5,9 +5,9 @@ const duplexer = require('duplexer2')
 const concat = require('concat-stream')
 const coffee = require('coffeescript')
 
-const coffeeStream = (function () {
+const coffeeStream = (() => {
   const output = through()
-  const input = concat(function (body) {
+  const input = concat((body) => {
     output.queue(coffee.compile(body.toString()))
     output.queue(null)
   })

--- a/example/loud_delay.js
+++ b/example/loud_delay.js
@@ -1,13 +1,12 @@
 const trumpet = require('../')
 const through = require('through2')
 const fs = require('fs')
-const tr = trumpet()
 
+const tr = trumpet()
 const loud = tr.select('.loud').createStream()
-loud.pipe(through(function (buf, enc, next) {
-  const self = this
-  setTimeout(function () {
-    self.push(buf.toString().toUpperCase())
+loud.pipe(through((buf, enc, next) => {
+  setTimeout(() => {
+    this.push(buf.toString().toUpperCase())
     next()
   }, 10)
 })).pipe(loud)

--- a/example/loud_delay.js
+++ b/example/loud_delay.js
@@ -6,7 +6,7 @@ const tr = trumpet()
 const loud = tr.select('.loud').createStream()
 loud.pipe(through((buf, enc, next) => {
   setTimeout(() => {
-    this.push(buf.toString().toUpperCase())
+    this.push(String(buf).toUpperCase())
     next()
   }, 10)
 })).pipe(loud)

--- a/example/read.js
+++ b/example/read.js
@@ -1,7 +1,7 @@
 const trumpet = require('../')
-const tr = trumpet()
+const fs = require('fs')
 
+const tr = trumpet()
 tr.select('.msg').createReadStream().pipe(process.stdout)
 
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/read.html`).pipe(tr)

--- a/example/read_all.js
+++ b/example/read_all.js
@@ -1,9 +1,9 @@
 const trumpet = require('../')
-const tr = trumpet()
+const fs = require('fs')
 
-tr.selectAll('.b span', function (span) {
+const tr = trumpet()
+tr.selectAll('.b span', (span) => {
   span.createReadStream().pipe(process.stdout)
 })
 
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/read_all.html`).pipe(tr)

--- a/example/read_modify_write.js
+++ b/example/read_modify_write.js
@@ -1,23 +1,23 @@
 const trumpet = require('../')
 const through = require('through2')
+const fs = require('fs')
 
 const tr = trumpet()
 
 // select all element and apply transformation function to selections
-tr.selectAll('.x span', function (element) {
+tr.selectAll('.x span', (element) => {
   // define function to transform input
-  const upper = through(function (buf) {
+  const upper = through((buf) => {
     this.queue(buf.toString().toUpperCase())
   })
 
-  // create a read/write stream for selected selement
-  const estream = element.createStream()
+  // create a read/write stream for selected element
+  const stream = element.createStream()
 
   // stream the element's inner html to transformation function
   // then stream the transformed output back into the element stream
-  estream.pipe(upper).pipe(estream)
+  stream.pipe(upper).pipe(stream)
 })
 
 // stream in html to trumpet and stream processed output to stdout
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/uppercase.html`).pipe(tr).pipe(process.stdout)

--- a/example/read_modify_write.js
+++ b/example/read_modify_write.js
@@ -8,7 +8,7 @@ const tr = trumpet()
 tr.selectAll('.x span', (element) => {
   // define function to transform input
   const upper = through((buf) => {
-    this.queue(buf.toString().toUpperCase())
+    this.queue(String(buf).toUpperCase())
   })
 
   // create a read/write stream for selected element

--- a/example/read_text.js
+++ b/example/read_text.js
@@ -1,11 +1,11 @@
 const trumpet = require('../')
-const tr = trumpet()
+const fs = require('fs')
 
-tr.selectAll('html *', function (elem) {
+const tr = trumpet()
+tr.selectAll('html *', (elem) => {
   elem.createReadStream()
     .pipe(elem.createWriteStream({ outer: true }))
 })
 tr.select('html').createReadStream().pipe(process.stdout)
 
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/read_all.html`).pipe(tr)

--- a/example/replace-inner.js
+++ b/example/replace-inner.js
@@ -1,4 +1,6 @@
 const trumpet = require('../')
+const fs = require('fs')
+
 const tr = trumpet()
 
 // pipe results to stdout
@@ -9,5 +11,4 @@ const ws = tr.select('tbody').createWriteStream()
 ws.end('<tr><td>rawr</td></tr>')
 
 // pipe html from file to trumpet for this example
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/table.html`).pipe(tr)

--- a/example/write.js
+++ b/example/write.js
@@ -1,9 +1,10 @@
 const trumpet = require('../')
+const fs = require('fs')
+
 const tr = trumpet()
 tr.pipe(process.stdout)
 
 const ws = tr.select('title').createWriteStream()
 ws.end('beep boop.')
 
-const fs = require('fs')
 fs.createReadStream(`${__dirname}/html/write.html`).pipe(tr)

--- a/index.js
+++ b/index.js
@@ -1,195 +1,188 @@
 const Duplex = require('readable-stream').Duplex
-const inherits = require('inherits')
+const Wrapper = require('./lib/wrap.js')
 const through2 = require('through2')
 const duplexer = require('duplexer2')
-
 const tokenize = require('html-tokenize')
 const select = require('html-select2')
 
-const wrapElem = require('./lib/wrap.js')
+class Trumpet extends Duplex {
+  #writing = false;
+  #piping = false;
+  #tokenize = tokenize();
+  #selected = this.#tokenize.pipe(select());
 
-module.exports = Trumpet
-inherits(Trumpet, Duplex)
+  constructor (options) {
+    super(options)
+    this.#selected.once('end', () => {
+      this.emit('_end')
+      this.push(null)
+    })
+    this.once('finish', () => {
+      this.#tokenize.end()
+    })
+  }
 
-function Trumpet () {
-  const self = this
-  if (!(this instanceof Trumpet)) return new Trumpet()
-  Duplex.call(this)
-  this._tokenize = tokenize()
-  this._writing = false
-  this._piping = false
-  this._select = this._tokenize.pipe(select())
-  this._select.once('end', function () {
-    self.emit('_end')
-    self.push(null)
-  })
-  this.once('finish', function () { self._tokenize.end() })
-}
+  select (str, cb) {
+    let first = true
+    const res = this.selectAll(str, (elem) => {
+      if (!first) return
+      first = false
+      res.createReadStream = () => {}
+      res.createWriteStream = () => {}
+      res.createStream = () => {}
+      if (cb) cb(elem)
+    })
+    return res
+  }
 
-Trumpet.prototype.pipe = function () {
-  this._piping = true
-  return Duplex.prototype.pipe.apply(this, arguments)
-}
+  // override stream
+  pipe () {
+    this.#piping = true
+    return super.pipe.apply(this, arguments)
+  }
 
-Trumpet.prototype._read = function (n) {
-  let row
-  const self = this
-  let read = 0
-  const s = this._select
-  while ((row = s.read()) !== null) {
-    if (row[0] === 'END') {
-      this.push(row[1][1])
+  selectAll (str, cb) {
+    const readers = []
+    const writers = []
+    const duplex = []
+    const gets = []
+    const getss = []
+    const sets = []
+    const removes = []
+
+    this.once('_end', () => {
+      readers.splice(0).forEach((r) => {
+        r.end()
+        r.resume()
+      })
+
+      duplex.splice(0).forEach((d) => {
+        d.input.end()
+        d.input.resume()
+      })
+    })
+
+    let welem
+    this.#selected.select(str, (elem) => {
+      welem = new Wrapper(elem)
+      if (cb) cb(welem)
+
+      elem.once('close', () => {
+        welem = null
+      })
+
+      readers.splice(0).forEach((r) => {
+        welem.createReadStream(r._options).pipe(r)
+      })
+
+      writers.splice(0).forEach((w) => {
+        w.pipe(welem.createWriteStream(w._options))
+      })
+
+      duplex.splice(0).forEach((d) => {
+        d.input.pipe(welem.createStream(d.options))
+          .pipe(d.output)
+      })
+
+      gets.splice(0).forEach((g) => {
+        welem.getAttribute(g[0], g[1])
+      })
+
+      getss.splice(0).forEach((cb) => {
+        welem.getAttributes(cb)
+      })
+
+      sets.splice(0).forEach((g) => {
+        welem.setAttribute(g[0], g[1])
+      })
+
+      removes.splice(0).forEach((key) => {
+        welem.removeAttribute(key)
+      })
+    })
+
+    return {
+      getAttribute: (key, cb) => {
+        if (welem) return welem.getAttribute(key, cb)
+        gets.push([key, cb])
+        return this
+      },
+      getAttributes: (cb) => {
+        getss.push(cb)
+        return this
+      },
+      setAttribute: (key, value) => {
+        if (welem) return welem.setAttribute(key, value)
+        sets.push([key, value])
+        return this
+      },
+      removeAttribute: (key) => {
+        if (welem) return welem.removeAttribute(key)
+        removes.push(key)
+        return this
+      },
+      createReadStream: (opts) => {
+        if (welem) return welem.createReadStream(opts)
+        const r = through2()
+        r._options = opts
+        readers.push(r)
+        return r
+      },
+      createWriteStream: (opts) => {
+        if (welem) return welem.createWriteStream(opts)
+        const w = through2()
+        w._options = opts
+        writers.push(w)
+        return w
+      },
+      createStream: (opts) => {
+        if (welem) return welem.createStream(opts)
+        const d = { input: through2(), output: through2() }
+        d.options = opts
+        duplex.push(d)
+        return duplexer(d.input, d.output)
+      }
+    }
+  }
+
+  // override stream
+  _read (n) {
+    let read = 0
+    let row
+    while ((row = this.#selected.read()) !== null) {
+      if (row[0] === 'END') {
+        this.push(row[1][1])
+      } else if (row[1] && row[1].length) {
+        this.push(row[1])
+      }
       read++
-    } else if (row[1] && row[1].length) {
-      this.push(row[1])
-      read++
     }
+    if (read === 0) this.#selected.once('readable', () => { this._read(n) })
   }
-  if (read === 0) s.once('readable', function () { self._read(n) })
-}
 
-Trumpet.prototype._write = function (buf, enc, next) {
-  if (!this._writing && !this._piping) {
-    this._piping = true
-    this.resume()
+  // override stream
+  _write (buf, enc, next) {
+    if (!this.#writing && !this.#piping) {
+      this.#piping = true
+      this.resume()
+    }
+    // _write is member of readable-stream.Transform
+    // noinspection JSUnresolvedFunction
+    return this.#tokenize._write(buf, enc, next)
   }
-  return this._tokenize._write(buf, enc, next)
-}
 
-Trumpet.prototype.select = function (str, cb) {
-  const self = this
-  let first = true
+  createReadStream (sel, opts) {
+    return this.select(sel).createReadStream(opts)
+  }
 
-  const res = self._selectAll(str, function (elem) {
-    if (!first) return
-    first = false
-    res.createReadStream = function () {
-    }
-    res.createWriteStream = function () {
-    }
-    res.createStream = function () {
-    }
-    if (cb) cb(elem)
-  })
-  return res
-}
+  createWriteStream (sel, opts) {
+    return this.select(sel).createWriteStream(opts)
+  }
 
-Trumpet.prototype.selectAll = function (str, cb) {
-  return this._selectAll(str, cb)
-}
-
-Trumpet.prototype._selectAll = function (str, cb) {
-  const readers = []
-  const writers = []
-  const duplex = []
-  const gets = []
-  const getss = []
-  const sets = []
-  const removes = []
-
-  this.once('_end', function () {
-    readers.splice(0).forEach(function (r) {
-      r.end()
-      r.resume()
-    })
-
-    duplex.splice(0).forEach(function (d) {
-      d.input.end()
-      d.input.resume()
-    })
-  })
-
-  let welem
-  this._select.select(str, function (elem) {
-    welem = wrapElem(elem)
-    if (cb) cb(welem)
-
-    elem.once('close', function () {
-      welem = null
-    })
-
-    readers.splice(0).forEach(function (r) {
-      welem.createReadStream(r._options).pipe(r)
-    })
-
-    writers.splice(0).forEach(function (w) {
-      w.pipe(welem.createWriteStream(w._options))
-    })
-
-    duplex.splice(0).forEach(function (d) {
-      d.input.pipe(welem.createStream(d.options))
-        .pipe(d.output)
-    })
-
-    gets.splice(0).forEach(function (g) {
-      welem.getAttribute(g[0], g[1])
-    })
-
-    getss.splice(0).forEach(function (cb) {
-      welem.getAttributes(cb)
-    })
-
-    sets.splice(0).forEach(function (g) {
-      welem.setAttribute(g[0], g[1])
-    })
-
-    removes.splice(0).forEach(function (key) {
-      welem.removeAttribute(key)
-    })
-  })
-
-  return {
-    getAttribute: function (key, cb) {
-      if (welem) return welem.getAttribute(key, cb)
-      gets.push([key, cb])
-      return this
-    },
-    getAttributes: function (cb) {
-      getss.push(cb)
-      return this
-    },
-    setAttribute: function (key, value) {
-      if (welem) return welem.setAttribute(key, value)
-      sets.push([key, value])
-      return this
-    },
-    removeAttribute: function (key) {
-      if (welem) return welem.removeAttribute(key)
-      removes.push(key)
-      return this
-    },
-    createReadStream: function (opts) {
-      if (welem) return welem.createReadStream(opts)
-      const r = through2()
-      r._options = opts
-      readers.push(r)
-      return r
-    },
-    createWriteStream: function (opts) {
-      if (welem) return welem.createWriteStream(opts)
-      const w = through2()
-      w._options = opts
-      writers.push(w)
-      return w
-    },
-    createStream: function (opts) {
-      if (welem) return welem.createStream(opts)
-      const d = { input: through2(), output: through2() }
-      d.options = opts
-      duplex.push(d)
-      return duplexer(d.input, d.output)
-    }
+  createStream (sel, opts) {
+    return this.select(sel).createStream(opts)
   }
 }
 
-Trumpet.prototype.createReadStream = function (sel, opts) {
-  return this.select(sel).createReadStream(opts)
-}
-
-Trumpet.prototype.createWriteStream = function (sel, opts) {
-  return this.select(sel).createWriteStream(opts)
-}
-
-Trumpet.prototype.createStream = function (sel, opts) {
-  return this.select(sel).createStream(opts)
-}
+module.exports = () => { return new Trumpet() }
+module.exports.Trumpet = Trumpet

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -2,94 +2,97 @@ const Duplex = require('readable-stream').Duplex
 const Readable = require('readable-stream').Readable
 const Writable = require('readable-stream').Writable
 
-module.exports = function (elem) {
-  const welem = {}
+const wrappedRead = (stream, readable) => {
+  return () => {
+    let row
+    let reads = 0
+    while ((row = stream.read()) !== null) {
+      if (row[1].length) {
+        readable.push(row[1])
+        reads++
+      }
+    }
+    if (reads === 0) stream.once('readable', wrappedRead(stream, readable))
+  }
+}
 
-  welem.name = elem.name
+class Wrapper {
+  #elem;
 
-  welem.getAttribute = function (key, cb) {
-    const value = elem.getAttribute(String(key).toLowerCase())
+  constructor (elem) {
+    this.#elem = elem
+  }
+
+  get name () {
+    return this.#elem.name
+  }
+
+  set name (value) {
+    this.#elem.name = value
+  }
+
+  getAttribute (key, cb) {
+    const value = this.#elem.getAttribute(String(key).toLowerCase())
     if (cb) cb(value)
     return value
   }
 
-  welem.getAttributes = function (cb) {
-    const attrs = elem.getAttributes()
+  getAttributes (cb) {
+    const attrs = this.#elem.getAttributes()
     if (cb) cb(attrs)
     return attrs
   }
 
-  welem.setAttribute = function (key, value) {
-    elem.setAttribute(key, value)
+  setAttribute (key, value) {
+    this.#elem.setAttribute(key, value)
   }
 
-  welem.removeAttribute = function (key) {
-    elem.removeAttribute(key)
+  removeAttribute (key) {
+    this.#elem.removeAttribute(key)
   }
 
-  welem.createReadStream = function (opts) {
+  createReadStream (opts) {
     if (!opts) opts = {}
 
-    const rs = elem.createReadStream({ inner: !opts.outer })
+    const rs = this.#elem.createReadStream({ inner: !opts.outer })
     const r = new Readable()
-    r._read = function read () {
-      let row
-      let reads = 0
-      while ((row = rs.read()) !== null) {
-        if (row[1].length) {
-          r.push(row[1])
-          reads++
-        }
-      }
-      if (reads === 0) rs.once('readable', read)
-    }
-    rs.on('end', function () { r.push(null) })
+    r._read = wrappedRead(rs, r)
+    rs.on('end', () => { r.push(null) })
 
     return r
   }
 
-  welem.createWriteStream = function (opts) {
+  createWriteStream (opts) {
     if (!opts) opts = {}
 
-    const ws = elem.createWriteStream({ inner: !opts.outer })
+    const ws = this.#elem.createWriteStream({ inner: !opts.outer })
     const w = new Writable()
-    w._write = function (buf, enc, next) {
+    w._write = (buf, enc, next) => {
       ws.write(['data', buf])
       next()
     }
-    w.on('finish', function () { ws.end() })
+    w.on('finish', () => { ws.end() })
 
     return w
   }
 
-  welem.createStream = function (opts) {
+  createStream (opts) {
     if (!opts) opts = {}
 
+    const s = this.#elem.createStream({ inner: !opts.outer })
     const d = new Duplex()
-    const s = elem.createStream({ inner: !opts.outer })
 
-    d._write = function (buf, enc, next) {
+    d._write = (buf, enc, next) => {
       s.write(['data', buf])
       next()
     }
+    d._read = wrappedRead(s, d)
 
-    d._read = function read () {
-      let row
-      let reads = 0
-      while ((row = s.read()) !== null) {
-        if (row[1].length) {
-          d.push(row[1])
-          reads++
-        }
-      }
-      if (reads === 0) s.once('readable', read)
-    }
-
-    d.on('finish', function () { s.end() })
-    s.on('end', function () { d.push(null) })
+    d.on('finish', () => { s.end() })
+    s.on('end', () => { d.push(null) })
 
     return d
   }
-
-  return welem
 }
+
+module.exports = Wrapper

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "node-trumpet2",
+  "name": "@gofunky/trumpet",
   "description": "parse and transform streaming html using css selectors",
   "main": "index.js",
   "dependencies": {
     "duplexer2": "~0.1.4",
     "html-select2": "^1.0.2",
     "html-tokenize": "^2.0.1",
-    "inherits": "^2.0.4",
     "readable-stream": "^3.4.0",
     "through2": "^4.0.2"
   },
   "devDependencies": {
     "@hutson/npm-deploy-git-tag": "6.0.0",
+    "babel-eslint": "^10.1.0",
     "codecov": "3.7.2",
     "coffeescript": "2.5.1",
     "concat-stream": "2.0.0",
@@ -20,7 +20,6 @@
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
-    "eslint-plugin-react": "7.20.6",
     "eslint-plugin-standard": "4.0.1",
     "htmlclean": "3.0.8",
     "json": "9.0.6",
@@ -34,30 +33,36 @@
   "scripts": {
     "test": "tape test/*.js | tap-spec",
     "coverage": "nyc --reporter=lcov tape test/*.js | tap-nyc",
-    "report": "nyc report --reporter=html"
+    "report": "nyc report --reporter=html",
+    "lint": "standard",
+    "deploy": "npm-deploy-git-tag"
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/gofunky/node-trumpet2.git"
+    "url": "http://github.com/gofunky/trumpet.git"
   },
   "keywords": [
     "html",
-    "streaming",
+    "stream",
     "parser",
     "transform",
-    "selectors",
-    "css"
+    "selector",
+    "css",
+    "library"
   ],
   "author": {
     "name": "matfax",
     "email": "mat@fax.fyi",
-    "url": "https://github.com/gofunky/node-trumpet2"
+    "url": "https://github.com/gofunky/trumpet"
   },
   "license": "MIT",
   "engine": {
-    "node": ">= 10.13.0 <15"
+    "node": ">= 12.18.3 <15"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "standard": {
+    "parser": "babel-eslint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "concat-stream": "2.0.0",
     "eslint": "7.7.0",
     "eslint-config-standard": "14.1.1",
+    "eslint-plugin-html": "^6.0.3",
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
@@ -34,7 +35,7 @@
     "test": "tape test/*.js | tap-spec",
     "coverage": "nyc --reporter=lcov tape test/*.js | tap-nyc",
     "report": "nyc report --reporter=html",
-    "lint": "standard",
+    "lint": "eslint",
     "deploy": "npm-deploy-git-tag"
   },
   "repository": {
@@ -56,13 +57,17 @@
     "url": "https://github.com/gofunky/trumpet"
   },
   "license": "MIT",
-  "engine": {
+  "engines": {
     "node": ">= 12.18.3 <15"
   },
   "publishConfig": {
     "access": "public"
   },
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "babel-eslint",
+    "filename": "**./*.html **/*.js",
+    "plugins": [
+      "html"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
-    "htmlclean": "3.0.8",
+    "htmlclean": "^3.0.8",
     "json": "9.0.6",
     "nyc": "15.1.0",
     "standard": "14.3.4",

--- a/test/article.html
+++ b/test/article.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>
@@ -51,7 +51,8 @@ Site News : Check out <a href="http://www.telize.com">Telize</a>, a JSON IP and 
 <article data-news-id="5783"><a class="uparrow" href="#up">&#9650;</a> <h2><a href="http://technical.io/" rel="nofollow">Tessel : an Internet-connected microcontroller for software developers, powered by JavaScript</a></h2> <address>at technical.io</address><a class="downarrow" href="#down">&#9660;</a><p><span class="upvotes">17</span> up and <span class="downvotes">0</span> down, posted by <username><a href="/user/echojs">echojs</a></username> 10 days ago <a href="/news/5783">1 comment</a></p></article>
 </section>
 </div>
-<footer><a href="/about">about</a> | <a href="http://github.com/antirez/lamernews">source code</a> | <a href="/rss">rss feed</a> | <a href="http://twitter.com/echojs">twitter</a></footer><script>setKeyboardNavigation();</script> <div style="display: none;" id="keyboard-help">
+<footer><a href="/about">about</a> | <a href="http://github.com/antirez/lamernews">source code</a> | <a href="/rss">rss feed</a> | <a href="http://twitter.com/echojs">twitter</a></footer>
+<div style="display: none;" id="keyboard-help">
 <div class="keyboard-help-banner banner-background banner">
 </div>
  <div class="keyboard-help-banner banner-foreground banner">

--- a/test/article.js
+++ b/test/article.js
@@ -7,11 +7,11 @@ test((t) => {
   t.plan(2)
 
   const tr = trumpet()
-  tr.createReadStream('article username').pipe(concat(function (body) {
+  tr.createReadStream('article username').pipe(concat((body) => {
     t.equal(body.toString(), '<a href="/user/echojs">echojs</a>')
   }))
 
-  tr.createReadStream('article span').pipe(concat(function (body) {
+  tr.createReadStream('article span').pipe(concat((body) => {
     t.equal(body.toString(), '2')
   }))
 

--- a/test/article.js
+++ b/test/article.js
@@ -8,11 +8,11 @@ test((t) => {
 
   const tr = trumpet()
   tr.createReadStream('article username').pipe(concat((body) => {
-    t.equal(body.toString(), '<a href="/user/echojs">echojs</a>')
+    t.equal(String(body), '<a href="/user/echojs">echojs</a>')
   }))
 
   tr.createReadStream('article span').pipe(concat((body) => {
-    t.equal(body.toString(), '2')
+    t.equal(String(body), '2')
   }))
 
   fs.createReadStream(`${__dirname}/article.html`).pipe(tr)

--- a/test/attr_and_deeper.js
+++ b/test/attr_and_deeper.js
@@ -3,22 +3,22 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlClean')
 
 const expected = '<div class="row cool"><div key="msg">wow</div></div>'
 
 test('attr and deeper', async (t) => {
   const sel = select()
-  sel.select('.row', function (elem) {
+  sel.select('.row', (elem) => {
     elem.setAttribute('class', 'row cool')
   })
-  sel.select('[key="msg"]', function (elem) {
+  sel.select('[key="msg"]', (elem) => {
     elem.createWriteStream({ outer: false }).end('wow')
   })
   fs.createReadStream(`${__dirname}/attr_and_deeper.html`)
     .pipe(sel)
-    .pipe(concat(function (body) {
-      t.equal(htmlclean(body.toString()), expected)
+    .pipe(concat((body) => {
+      t.equal(htmlClean(String(body)), expected)
       t.end()
     }))
 })

--- a/test/attr_and_deeper.js
+++ b/test/attr_and_deeper.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlClean = require('htmlClean')
+const htmlClean = require('htmlclean')
 
 const expected = '<div class="row cool"><div key="msg">wow</div></div>'
 

--- a/test/attribute_selectors.js
+++ b/test/attribute_selectors.js
@@ -3,43 +3,43 @@ const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
 
-test('selected element has attribute [att]', function (t) {
+test('selected element has attribute [att]', (t) => {
   t.plan(1)
 
   const tr = trumpet()
-  tr.createReadStream('li[data-foo]').pipe(concat(function (elem) {
+  tr.createReadStream('li[data-foo]').pipe(concat((elem) => {
     t.equal(elem.toString(), 'item2')
   }))
   fs.createReadStream(`${__dirname}/attribute_selectors.html`).pipe(tr)
 })
 
-test('selected element has attribute value [att=val]', function (t) {
+test('selected element has attribute value [att=val]', (t) => {
   t.plan(1)
 
   const tr = trumpet()
-  tr.createReadStream('li[class="item1 item-first"]').pipe(concat(function (elem) {
+  tr.createReadStream('li[class="item1 item-first"]').pipe(concat((elem) => {
     t.equal(elem.toString(), 'item1')
   }))
   fs.createReadStream(`${__dirname}/attribute_selectors.html`).pipe(tr)
 })
 
-test('selected element contains whitespace separated attribute value [att~=val]', function (t) {
+test('selected element contains whitespace separated attribute value [att~=val]', (t) => {
   t.plan(1)
 
   const tr = trumpet()
-  tr.createReadStream('li[class~=item-first]').pipe(concat(function (elem) {
+  tr.createReadStream('li[class~=item-first]').pipe(concat((elem) => {
     t.equal(elem.toString(), 'item1')
   }))
   fs.createReadStream(`${__dirname}/attribute_selectors.html`).pipe(tr)
 })
 
-test('selected element attribute value equals or starts with and followed by - [att|=val]', function (t) {
+test('selected element attribute value equals or starts with and followed by - [att|=val]', (t) => {
   const items = ['item1', 'item3', 'item4']
   t.plan(items.length)
 
   const tr = trumpet()
-  tr.selectAll('li[data-role|=item]', function (elem) {
-    elem.createReadStream().pipe(concat(function (src) {
+  tr.selectAll('li[data-role|=item]', (elem) => {
+    elem.createReadStream().pipe(concat((src) => {
       t.equal(src.toString(), items.shift())
     }))
   })
@@ -47,13 +47,13 @@ test('selected element attribute value equals or starts with and followed by - [
   fs.createReadStream(`${__dirname}/attribute_selectors.html`).pipe(tr)
 })
 
-test('selected element has attribute (att) value starting with (val) [att^=val]', function (t) {
+test('selected element has attribute (att) value starting with (val) [att^=val]', (t) => {
   const items = ['item1', 'item2', 'item3', 'item4']
   t.plan(items.length)
 
   const tr = trumpet()
-  tr.selectAll('li[class^=item]', function (elem) {
-    elem.createReadStream().pipe(concat(function (src) {
+  tr.selectAll('li[class^=item]', (elem) => {
+    elem.createReadStream().pipe(concat((src) => {
       t.equal(src.toString(), items.shift())
     }))
   })
@@ -61,13 +61,13 @@ test('selected element has attribute (att) value starting with (val) [att^=val]'
   fs.createReadStream(`${__dirname}/attribute_selectors.html`).pipe(tr)
 })
 
-test('selected element has attribute (att) value ending with (val) [att$=val]', function (t) {
+test('selected element has attribute (att) value ending with (val) [att$=val]', (t) => {
   const items = ['item4']
   t.plan(items.length)
 
   const tr = trumpet()
-  tr.selectAll('li[data-role$=last]', function (elem) {
-    elem.createReadStream().pipe(concat(function (src) {
+  tr.selectAll('li[data-role$=last]', (elem) => {
+    elem.createReadStream().pipe(concat((src) => {
       t.equal(src.toString(), items.shift())
     }))
   })
@@ -75,13 +75,13 @@ test('selected element has attribute (att) value ending with (val) [att$=val]', 
   fs.createReadStream(`${__dirname}/attribute_selectors.html`).pipe(tr)
 })
 
-test('selected element has attribute (att) value containing (val) [att*=val]', function (t) {
+test('selected element has attribute (att) value containing (val) [att*=val]', (t) => {
   const items = ['item2', 'item5']
   t.plan(items.length)
 
   const tr = trumpet()
-  tr.selectAll('li[data-foo*=random]', function (elem) {
-    elem.createReadStream().pipe(concat(function (src) {
+  tr.selectAll('li[data-foo*=random]', (elem) => {
+    elem.createReadStream().pipe(concat((src) => {
       t.equal(src.toString(), items.shift())
     }))
   })

--- a/test/child.js
+++ b/test/child.js
@@ -3,51 +3,51 @@ const fs = require('fs')
 const test = require('tape')
 const through = require('through2')
 
-test('child selector', function (t) {
+test('child selector', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.c > input[type=text]')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'abc')
   })
   fs.createReadStream(`${__dirname}/child.html`).pipe(tr)
 })
 
-test('child no-match selector', function (t) {
+test('child no-match selector', (t) => {
   t.plan(1)
 
   const tr = trumpet()
-  tr.pipe(through(null, function () {
+  tr.pipe(through(null, () => {
     t.ok(true)
   }))
   const elem = tr.select('.b > input[type=text]')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (_) => {
     t.fail('should not have matched')
   })
   fs.createReadStream(`${__dirname}/child.html`).pipe(tr)
 })
 
-test('child start then no match selector', function (t) {
+test('child start then no match selector', (t) => {
   t.plan(1)
 
   const tr = trumpet()
-  tr.pipe(through(null, function () {
+  tr.pipe(through(null, () => {
     t.ok(true)
   }))
   const elem = tr.select('.b > .d')
-  elem.getAttribute('class', function (value) {
+  elem.getAttribute('class', (_) => {
     t.fail('should not have matched')
   })
   fs.createReadStream(`${__dirname}/child.html`).pipe(tr)
 })
 
-test('child with similar grandchild selector', function (t) {
+test('child with similar grandchild selector', (t) => {
   t.plan(2)
 
   const tr = trumpet()
-  tr.selectAll('.a > div', function (elem) {
-    elem.getAttribute('class', function (value) {
+  tr.selectAll('.a > div', (elem) => {
+    elem.getAttribute('class', (value) => {
       t.notEqual(value, 'c', 'should not have matched')
     })
   })

--- a/test/comment.js
+++ b/test/comment.js
@@ -17,7 +17,7 @@ test('comment write stream', (t) => {
   const res = '<!-- test --><html></html>'
   tr.pipe(concat((body) => {
     t.equal(
-      body.toString(),
+      String(body),
       res
     )
   }))
@@ -38,7 +38,7 @@ test('comment write stream variant', (t) => {
   const res = '<!--test   --><html></html>'
   tr.pipe(concat((body) => {
     t.equal(
-      body.toString(),
+      String(body),
       res
     )
   }))

--- a/test/comment.js
+++ b/test/comment.js
@@ -3,7 +3,7 @@ const through = require('through2')
 const test = require('tape')
 const concat = require('concat-stream')
 
-test('comment write stream', function (t) {
+test('comment write stream', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -15,7 +15,7 @@ test('comment write stream', function (t) {
   s.end()
 
   const res = '<!-- test --><html></html>'
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       body.toString(),
       res
@@ -24,7 +24,7 @@ test('comment write stream', function (t) {
   tr.end(res)
 })
 
-test('comment write stream variant', function (t) {
+test('comment write stream variant', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -36,7 +36,7 @@ test('comment write stream variant', function (t) {
   s.end()
 
   const res = '<!--test   --><html></html>'
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       body.toString(),
       res

--- a/test/descendant.js
+++ b/test/descendant.js
@@ -3,26 +3,26 @@ const fs = require('fs')
 const test = require('tape')
 const through = require('through2')
 
-test('descendant selector', function (t) {
+test('descendant selector', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.a input[type=text]')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'abc')
   })
   fs.createReadStream(`${__dirname}/descendant.html`).pipe(tr)
 })
 
-test('descendant no-match selector', function (t) {
+test('descendant no-match selector', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.b .d')
-  elem.getAttribute('class', function (value) {
+  elem.getAttribute('class', (value) => {
     t.fail('should not have matched')
   })
   fs.createReadStream(`${__dirname}/descendant.html`).pipe(tr)
 
-  tr.pipe(through(null, function () { t.ok(true) }))
+  tr.pipe(through(null, () => { t.ok(true) }))
 })

--- a/test/first.js
+++ b/test/first.js
@@ -3,14 +3,14 @@ const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
 
-test('first', function (t) {
+test('first', (t) => {
   t.plan(2)
   const expected = ['AAA', 'DDD']
 
   const tr = trumpet()
-  tr.selectAll('.row *:first-child', function (elem) {
+  tr.selectAll('.row *:first-child', (elem) => {
     const ex = expected.shift()
-    elem.createReadStream().pipe(concat(function (body) {
+    elem.createReadStream().pipe(concat((body) => {
       t.equal(String(body), ex)
     }))
   })

--- a/test/get_attr.js
+++ b/test/get_attr.js
@@ -2,35 +2,35 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 
-test('get attribute', function (t) {
+test('get attribute', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.b input[type=text]')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, '¡¡¡')
   })
   fs.createReadStream(`${__dirname}/get_attr.html`).pipe(tr)
 })
 
-test('get 1 div', function (t) {
+test('get 1 div', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('div')
-  elem.getAttribute('class', function (value) {
+  elem.getAttribute('class', (value) => {
     t.equal(value, 'a')
   })
   fs.createReadStream(`${__dirname}/get_attr.html`).pipe(tr)
 })
 
-test('get all divs', function (t) {
+test('get all divs', (t) => {
   t.plan(2)
   const names = ['a', 'b']
 
   const tr = trumpet()
-  tr.selectAll('div', function (elem) {
-    elem.getAttribute('class', function (value) {
+  tr.selectAll('div', (elem) => {
+    elem.getAttribute('class', (value) => {
       t.equal(value, names.shift())
     })
   })

--- a/test/link.js
+++ b/test/link.js
@@ -3,7 +3,7 @@ const through = require('through2')
 const test = require('tape')
 const concat = require('concat-stream')
 
-test('write stream', function (t) {
+test('write stream', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -16,14 +16,14 @@ test('write stream', function (t) {
 
   s.write('beep')
 
-  setTimeout(function () {
+  setTimeout(() => {
     s.write(' boop.')
     s.end()
   }, 500)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      body.toString(),
+      String(body),
       '<html><body><a href="/beep">beep boop.</a></body></html>'
     )
   }))

--- a/test/loud.js
+++ b/test/loud.js
@@ -10,8 +10,8 @@ test('loud', (t) => {
   const tr = trumpet()
 
   const loud = tr.select('.loud').createStream()
-  loud.pipe(through((buf, enc, next) => {
-    this.push(buf.toString().toUpperCase())
+  loud.pipe(through(function (buf, enc, next) {
+    this.push(String(buf).toUpperCase())
     next()
   })).pipe(loud)
 

--- a/test/loud.js
+++ b/test/loud.js
@@ -5,19 +5,19 @@ const concat = require('concat-stream')
 const fs = require('fs')
 const expected = fs.readFileSync(`${__dirname}/loud_expected.html`, 'utf8')
 
-test('loud', function (t) {
+test('loud', (t) => {
   t.plan(1)
   const tr = trumpet()
 
   const loud = tr.select('.loud').createStream()
-  loud.pipe(through(function (buf, enc, next) {
+  loud.pipe(through((buf, enc, next) => {
     this.push(buf.toString().toUpperCase())
     next()
   })).pipe(loud)
 
   fs.createReadStream(`${__dirname}/loud.html`)
     .pipe(tr)
-    .pipe(concat(function (src) {
+    .pipe(concat((src) => {
       t.equal(String(src), expected)
     }))
 })

--- a/test/loud_delay.js
+++ b/test/loud_delay.js
@@ -5,22 +5,21 @@ const concat = require('concat-stream')
 const fs = require('fs')
 const expected = fs.readFileSync(`${__dirname}/loud_expected.html`, 'utf8')
 
-test('loud delay', function (t) {
+test('loud delay', (t) => {
   t.plan(1)
   const tr = trumpet()
 
   const loud = tr.select('.loud').createStream()
-  loud.pipe(through(function (buf, enc, next) {
-    const self = this
-    setTimeout(function () {
-      self.push(buf.toString().toUpperCase())
+  loud.pipe(through((buf, enc, next) => {
+    setTimeout(() => {
+      this.push(buf.toString().toUpperCase())
       next()
     }, 10)
   })).pipe(loud)
 
   fs.createReadStream(`${__dirname}/loud.html`)
     .pipe(tr)
-    .pipe(concat(function (src) {
+    .pipe(concat((src) => {
       t.equal(String(src), expected)
     }))
 })

--- a/test/loud_delay.js
+++ b/test/loud_delay.js
@@ -10,9 +10,9 @@ test('loud delay', (t) => {
   const tr = trumpet()
 
   const loud = tr.select('.loud').createStream()
-  loud.pipe(through((buf, enc, next) => {
+  loud.pipe(through(function (buf, enc, next) {
     setTimeout(() => {
-      this.push(buf.toString().toUpperCase())
+      this.push(String(buf).toUpperCase())
       next()
     }, 10)
   })).pipe(loud)

--- a/test/loud_delay_cb.js
+++ b/test/loud_delay_cb.js
@@ -5,16 +5,15 @@ const concat = require('concat-stream')
 const fs = require('fs')
 const expected = fs.readFileSync(`${__dirname}/loud_expected.html`, 'utf8')
 
-test('loud delay cb', function (t) {
+test('loud delay cb', (t) => {
   t.plan(1)
   const tr = trumpet()
 
-  tr.select('.loud', function (elem) {
+  tr.select('.loud', (elem) => {
     const loud = elem.createStream()
-    loud.pipe(through(function (buf, enc, next) {
-      const self = this
-      setTimeout(function () {
-        self.push(buf.toString().toUpperCase())
+    loud.pipe(through((buf, enc, next) => {
+      setTimeout(() => {
+        this.push(buf.toString().toUpperCase())
         next()
       }, 10)
     })).pipe(loud)
@@ -22,7 +21,7 @@ test('loud delay cb', function (t) {
 
   fs.createReadStream(`${__dirname}/loud.html`)
     .pipe(tr)
-    .pipe(concat(function (src) {
+    .pipe(concat((src) => {
       t.equal(String(src), expected)
     }))
 })

--- a/test/loud_delay_cb.js
+++ b/test/loud_delay_cb.js
@@ -11,9 +11,9 @@ test('loud delay cb', (t) => {
 
   tr.select('.loud', (elem) => {
     const loud = elem.createStream()
-    loud.pipe(through((buf, enc, next) => {
+    loud.pipe(through(function (buf, enc, next) {
       setTimeout(() => {
-        this.push(buf.toString().toUpperCase())
+        this.push(String(buf).toUpperCase())
         next()
       }, 10)
     })).pipe(loud)

--- a/test/misc_tags.js
+++ b/test/misc_tags.js
@@ -2,56 +2,56 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 
-test('h1 is first, select h1', function (t) {
+test('h1 is first, select h1', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.a h1')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'ah1')
   })
   fs.createReadStream(`${__dirname}/misc_tags.html`).pipe(tr)
 })
 
-test('h1 is first, select em', function (t) {
+test('h1 is first, select em', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.a em')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'aem')
   })
   fs.createReadStream(`${__dirname}/misc_tags.html`).pipe(tr)
 })
 
-test('em is first, select h1', function (t) {
+test('em is first, select h1', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.b h1')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'bh1')
   })
   fs.createReadStream(`${__dirname}/misc_tags.html`).pipe(tr)
 })
 
-test('em is first, select em', function (t) {
+test('em is first, select em', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.b em')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'bem')
   })
   fs.createReadStream(`${__dirname}/misc_tags.html`).pipe(tr)
 })
 
-test('deeply nested', function (t) {
+test('deeply nested', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('.c h1')
-  elem.getAttribute('value', function (value) {
+  elem.getAttribute('value', (value) => {
     t.equal(value, 'ch1')
   })
   fs.createReadStream(`${__dirname}/misc_tags.html`).pipe(tr)

--- a/test/multi_file_write_stream.js
+++ b/test/multi_file_write_stream.js
@@ -4,7 +4,7 @@ const test = require('tape')
 const concat = require('concat-stream')
 const htmlclean = require('htmlclean')
 
-test('multi file write stream in order', function (t) {
+test('multi file write stream in order', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -18,9 +18,9 @@ test('multi file write stream in order', function (t) {
   sx.pipe(wsx)
   sy.pipe(wsy)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(body.toString()),
+      htmlclean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_file_write_stream.js
+++ b/test/multi_file_write_stream.js
@@ -2,7 +2,7 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('multi file write stream in order', (t) => {
   t.plan(1)
@@ -20,7 +20,7 @@ test('multi file write stream in order', (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_file_write_stream_second_elem_streamed_first.js
+++ b/test/multi_file_write_stream_second_elem_streamed_first.js
@@ -2,9 +2,9 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlClean')
 
-test('multi file write stream out of order', function (t) {
+test('multi file write stream out of order', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -18,9 +18,9 @@ test('multi file write stream out of order', function (t) {
   sx.pipe(wsx)
   sy.pipe(wsy)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(body.toString()),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_file_write_stream_second_elem_streamed_first.js
+++ b/test/multi_file_write_stream_second_elem_streamed_first.js
@@ -2,7 +2,7 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlClean = require('htmlClean')
+const htmlClean = require('htmlclean')
 
 test('multi file write stream out of order', (t) => {
   t.plan(1)

--- a/test/multi_stream.js
+++ b/test/multi_stream.js
@@ -13,17 +13,17 @@ test('multiple read streams', async (t) => {
     'burritos'
   ]
   const output = through2()
-  output.pipe(concat(function (src) {
-    t.equal(src.toString(), 'tacosyburritos')
+  output.pipe(concat((src) => {
+    t.equal(String(src), 'tacosyburritos')
     t.end()
   }))
 
   const tr = trumpet()
-  tr.selectAll('.b span', function (span) {
+  tr.selectAll('.b span', (span) => {
     t.equal(span.name, 'span')
     const rs = span.createReadStream()
     rs.pipe(output, { end: false })
-    rs.pipe(concat(function (src) {
+    rs.pipe(concat((src) => {
       t.equal(String(src), html.shift())
     }))
   })

--- a/test/multi_write_stream.js
+++ b/test/multi_write_stream.js
@@ -32,7 +32,7 @@ test('multi write stream in order', (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(body.toString()),
+      htmlclean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_write_stream.js
+++ b/test/multi_write_stream.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const through = require('through2')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('multi write stream in order', (t) => {
   t.plan(1)
@@ -32,7 +32,7 @@ test('multi write stream in order', (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_write_stream.js
+++ b/test/multi_write_stream.js
@@ -5,7 +5,7 @@ const test = require('tape')
 const concat = require('concat-stream')
 const htmlclean = require('htmlclean')
 
-test('multi write stream in order', function (t) {
+test('multi write stream in order', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -20,17 +20,17 @@ test('multi write stream in order', function (t) {
   sx.write('beep')
   sy.write('beep')
 
-  setTimeout(function () {
+  setTimeout(() => {
     sx.write(' boop.')
     sx.end()
   }, 500)
 
-  setTimeout(function () {
+  setTimeout(() => {
     sy.write(' beep boop.')
     sy.end()
   }, 600)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       htmlclean(body.toString()),
       '<!doctype html>' +

--- a/test/multi_write_stream_second_elem_times_out_first.js
+++ b/test/multi_write_stream_second_elem_times_out_first.js
@@ -32,7 +32,7 @@ test('multi write stream out of order', (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlClean(body.toString()),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_write_stream_second_elem_times_out_first.js
+++ b/test/multi_write_stream_second_elem_times_out_first.js
@@ -3,9 +3,9 @@ const fs = require('fs')
 const through = require('through2')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlClean')
 
-test('multi write stream out of order', function (t) {
+test('multi write stream out of order', (t) => {
   t.plan(1)
 
   const tr = trumpet()
@@ -20,19 +20,19 @@ test('multi write stream out of order', function (t) {
   sx.write('beep')
   sy.write('beep')
 
-  setTimeout(function () {
+  setTimeout(() => {
     sx.write(' boop.')
     sx.end()
   }, 500)
 
-  setTimeout(function () {
+  setTimeout(() => {
     sy.write(' beep boop.')
     sy.end()
   }, 400)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(body.toString()),
+      htmlClean(body.toString()),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '<div class="y">beep beep boop.</div>' +

--- a/test/multi_write_stream_second_elem_times_out_first.js
+++ b/test/multi_write_stream_second_elem_times_out_first.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const through = require('through2')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlClean = require('htmlClean')
+const htmlClean = require('htmlclean')
 
 test('multi write stream out of order', (t) => {
   t.plan(1)

--- a/test/nbsp.js
+++ b/test/nbsp.js
@@ -5,14 +5,14 @@ const concat = require('concat-stream')
 const html = 'Category:&nbsp;&nbsp;&nbsp;<select></select>'
 const expected = 'Category:&nbsp;&nbsp;&nbsp;<select id="xyz"></select>'
 
-test('&nbsp;', function (t) {
+test('&nbsp;', (t) => {
   t.plan(1)
 
   const tr = trumpet()
   const elem = tr.select('select')
   elem.setAttribute('id', 'xyz')
 
-  tr.pipe(concat(function (src) {
+  tr.pipe(concat((src) => {
     t.equal(String(src), expected)
   }))
   tr.end(html)

--- a/test/overlapping_reads.js
+++ b/test/overlapping_reads.js
@@ -2,7 +2,7 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlClean = require('htmlClean')
+const htmlClean = require('htmlclean')
 
 test('stream all divs', (t) => {
   t.plan(3)

--- a/test/overlapping_reads.js
+++ b/test/overlapping_reads.js
@@ -2,9 +2,9 @@ const trumpet = require('../')
 const fs = require('fs')
 const test = require('tape')
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlClean')
 
-test('stream all divs', function (t) {
+test('stream all divs', (t) => {
   t.plan(3)
 
   const html = [
@@ -14,9 +14,9 @@ test('stream all divs', function (t) {
   ]
 
   const tr = trumpet()
-  tr.selectAll('div', function (div) {
-    div.createReadStream().pipe(concat(function (src) {
-      t.equal(htmlclean(src.toString()), html.shift())
+  tr.selectAll('div', (div) => {
+    div.createReadStream().pipe(concat((src) => {
+      t.equal(htmlClean(src.toString()), html.shift())
     }))
   })
   fs.createReadStream(`${__dirname}/overlapping_reads.html`).pipe(tr)

--- a/test/partial.js
+++ b/test/partial.js
@@ -4,17 +4,17 @@ const concat = require('concat-stream')
 const fs = require('fs')
 const expected = fs.readFileSync(`${__dirname}/partial_expected.html`, 'utf8')
 
-test('partial html', function (t) {
+test('partial html', (t) => {
   t.plan(1)
   const tr = trumpet()
 
-  tr.selectAll('script', function (node) {
+  tr.selectAll('script', (node) => {
     node.setAttribute('src', 'updated')
   })
 
   fs.createReadStream(`${__dirname}/partial.html`)
     .pipe(tr)
-    .pipe(concat(function (src) {
+    .pipe(concat((src) => {
       t.equal(String(src), expected)
     }))
 })

--- a/test/rebase.js
+++ b/test/rebase.js
@@ -6,7 +6,7 @@ const test = tryToTape(require('tape'))
 test('wonky duplicated classes selector', async (t) => {
   const tr = trumpet()
   const elem = tr.select('.c')
-  elem.getAttribute('class', function (value) {
+  elem.getAttribute('class', (value) => {
     t.equal(value, 'c')
     t.end()
   })
@@ -16,7 +16,7 @@ test('wonky duplicated classes selector', async (t) => {
 test('rebase selector', async (t) => {
   const tr = trumpet()
   const elem = tr.select('.a > .b > * > .d')
-  elem.getAttribute('class', function (value) {
+  elem.getAttribute('class', (value) => {
     t.equal(value, 'd')
     t.end()
   })

--- a/test/rm_attr.js
+++ b/test/rm_attr.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('remove attribute', async (t) => {
   const tr = trumpet()
@@ -12,7 +12,7 @@ test('remove attribute', async (t) => {
 
   tr.pipe(concat(src => {
     t.equal(
-      htmlclean(String(src)),
+      htmlClean(String(src)),
       '<div class="a"><input type="text" value="xyz"></div>'
     )
     t.end()

--- a/test/script_tr.js
+++ b/test/script_tr.js
@@ -34,7 +34,7 @@ test('uppercase script outer', async (t) => {
     callback(null, String(chunk).toUpperCase())
   })).pipe(ts)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       body.toString(),
       '<html><head>' +

--- a/test/script_tr.js
+++ b/test/script_tr.js
@@ -13,7 +13,7 @@ test('uppercase script contents', async (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      body.toString(),
+      String(body),
       '<html><head>' +
       '<script type="robots">BEEPITY BOOP</script>' +
       '</head></html>'
@@ -36,7 +36,7 @@ test('uppercase script outer', async (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      body.toString(),
+      String(body),
       '<html><head>' +
       '<SCRIPT TYPE="ROBOTS">BEEPITY BOOP</SCRIPT>' +
       '</head></html>'

--- a/test/set_attr.js
+++ b/test/set_attr.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('set attribute', async (t) => {
   const tr = trumpet()
@@ -12,7 +12,7 @@ test('set attribute', async (t) => {
 
   tr.pipe(concat(src => {
     t.equal(
-      htmlclean(String(src)),
+      htmlClean(String(src)),
       '<div class="a"><input type="text" value="abc"></div>'
     )
     t.end()
@@ -27,7 +27,7 @@ test('create attribute', async (t) => {
 
   tr.pipe(concat(src => {
     t.equal(
-      htmlclean(String(src)),
+      htmlClean(String(src)),
       '<div class="a"><input type="text" value="xyz" beep="boop"></div>'
     )
     t.end()

--- a/test/set_attrs.js
+++ b/test/set_attrs.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('set attributes', async (t) => {
   const tr = trumpet()
@@ -13,7 +13,7 @@ test('set attributes', async (t) => {
 
   tr.pipe(concat((src) => {
     t.equal(
-      htmlclean(String(src)),
+      htmlClean(String(src)),
       '<div class="a"><input type="text" value="XYZ"></div>' +
       '<div class="a"><input type="text" value="GHI"></div>'
     )
@@ -30,7 +30,7 @@ test('create attributes', async (t) => {
 
   tr.pipe(concat((src) => {
     t.equal(
-      htmlclean(String(src)),
+      htmlClean(String(src)),
       '<div class="a"><input type="text" value="xyz" beep="boop"></div>' +
       '<div class="a"><input type="text" value="ghi" beep="boop"></div>'
     )

--- a/test/through_stream.js
+++ b/test/through_stream.js
@@ -4,7 +4,7 @@ const through2 = require('through2')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('outer through stream', async (t) => {
   const tr = trumpet()
@@ -15,7 +15,7 @@ test('outer through stream', async (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<html><body><DIV>XYZ</DIV></body></html>'
     )
     t.end()
@@ -33,7 +33,7 @@ test('through stream', async (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<html><body><div>XYZ</div></body></html>'
     )
     t.end()

--- a/test/through_stream.js
+++ b/test/through_stream.js
@@ -13,7 +13,7 @@ test('outer through stream', async (t) => {
     callback(null, String(chunk).toUpperCase())
   })).pipe(ts)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       htmlclean(String(body)),
       '<html><body><DIV>XYZ</DIV></body></html>'
@@ -31,7 +31,7 @@ test('through stream', async (t) => {
     callback(null, String(chunk).toUpperCase())
   })).pipe(ts)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       htmlclean(String(body)),
       '<html><body><div>XYZ</div></body></html>'

--- a/test/triple_through_stream.js
+++ b/test/triple_through_stream.js
@@ -4,7 +4,7 @@ const through2 = require('through2')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlClean = require('htmlClean')
+const htmlClean = require('htmlclean')
 
 test('through stream thrice', async (t) => {
   const tr = trumpet()

--- a/test/triple_through_stream.js
+++ b/test/triple_through_stream.js
@@ -4,20 +4,20 @@ const through2 = require('through2')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlClean')
 
 test('through stream thrice', async (t) => {
   const tr = trumpet()
-  tr.selectAll('div', function (div) {
+  tr.selectAll('div', (div) => {
     const ts = div.createStream()
     ts.pipe(through2.obj((chunk, _, callback) => {
-      callback(null, htmlclean(String(chunk)).toUpperCase())
+      callback(null, htmlClean(String(chunk)).toUpperCase())
     })).pipe(ts)
   })
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<html><body>' +
       '<div>ABC</div>' +
       '<div>DEF</div>' +

--- a/test/write_end.js
+++ b/test/write_end.js
@@ -3,18 +3,18 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlClean')
 
 test('write end', async (t) => {
   const tr = trumpet()
-  tr.select('.x b', function (elem) {
+  tr.select('.x b', (elem) => {
     const ws = elem.createWriteStream()
     ws.end('beep boop')
   })
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x"><b>beep boop</b></div>' +
       '</body></html>'
@@ -27,14 +27,14 @@ test('write end', async (t) => {
 
 test('write end string', async (t) => {
   const tr = trumpet()
-  tr.select('.x b', function (elem) {
+  tr.select('.x b', (elem) => {
     const ws = elem.createWriteStream()
     ws.end('beep boop')
   })
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x"><b>beep boop</b></div>' +
       '</body></html>'

--- a/test/write_end.js
+++ b/test/write_end.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlClean = require('htmlClean')
+const htmlClean = require('htmlclean')
 
 test('write end', async (t) => {
   const tr = trumpet()

--- a/test/write_stream.js
+++ b/test/write_stream.js
@@ -4,7 +4,7 @@ const through2 = require('through2')
 const tryToTape = require('try-to-tape')
 const test = tryToTape(require('tape'))
 const concat = require('concat-stream')
-const htmlclean = require('htmlclean')
+const htmlClean = require('htmlclean')
 
 test('outer write stream', async (t) => {
   const tr = trumpet()
@@ -21,7 +21,7 @@ test('outer write stream', async (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body> <B>beep boop.</B></body></html>'
     )
@@ -46,7 +46,7 @@ test('write stream', async (t) => {
 
   tr.pipe(concat((body) => {
     t.equal(
-      htmlclean(String(body)),
+      htmlClean(String(body)),
       '<!doctype html>' +
       '<html><body><div class="x">beep boop.</div>' +
       '</body></html>'

--- a/test/write_stream.js
+++ b/test/write_stream.js
@@ -14,12 +14,12 @@ test('outer write stream', async (t) => {
 
   s.write('<B>beep')
 
-  setTimeout(function () {
+  setTimeout(() => {
     s.write(' boop.</B>')
     s.end()
   }, 500)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       htmlclean(String(body)),
       '<!doctype html>' +
@@ -39,12 +39,12 @@ test('write stream', async (t) => {
 
   s.write('beep')
 
-  setTimeout(function () {
+  setTimeout(() => {
     s.write(' boop.')
     s.end()
   }, 500)
 
-  tr.pipe(concat(function (body) {
+  tr.pipe(concat((body) => {
     t.equal(
       htmlclean(String(body)),
       '<!doctype html>' +

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,6 +801,36 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.0.1.tgz#79695eb49af3cd8abc8d93a73da382deb1ca0795"
+  integrity sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
+domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
+domutils@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.2.0.tgz#f3ce1610af5c30280bde1b71f84b018b958f32cf"
+  integrity sha512-0haAxVr1PR0SqYwCH7mxMpHZUwjih9oPPedqpR/KufsnxPyZ9dyVw1R5093qnJF3WXSbjBkdzRWLw/knJV/fAg==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+
 dotignore@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"
@@ -843,6 +873,11 @@ enquirer@^2.3.5:
   integrity sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==
   dependencies:
     ansi-colors "^3.2.1"
+
+entities@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -970,6 +1005,13 @@ eslint-plugin-es@^3.0.0:
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
+
+eslint-plugin-html@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-6.0.3.tgz#8d9d2c187d1a48ed78d84f45e29820f102425e51"
+  integrity sha512-1KV2ebQHywlXkfpXOGjxuEyoq+g6AWvD6g9TB28KsGhbM5rJeHXAEpHOev6LqZv6ylcfa9BWokDsNVKyYefzGw==
+  dependencies:
+    htmlparser2 "^4.1.0"
 
 eslint-plugin-import@2.22.0:
   version "2.22.0"
@@ -1500,6 +1542,16 @@ htmlclean@3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/htmlclean/-/htmlclean-3.0.8.tgz#cea451cf5399d4018386a57129489f2d630e62b0"
   integrity sha1-zqRRz1OZ1AGDhqVxKUifLWMOYrA=
+
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-proxy-agent@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/core@^7.7.5":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.7.tgz#ee155d2e12300bcc0cff6a8ad46f2af5063803e9"
@@ -27,6 +34,15 @@
     lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.11.0":
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.4.tgz#1ec7eec00defba5d6f83e50e3ee72ae2fee482be"
+  integrity sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==
+  dependencies:
+    "@babel/types" "^7.11.0"
+    jsesc "^2.5.1"
     source-map "^0.5.0"
 
 "@babel/generator@^7.7.4":
@@ -49,6 +65,15 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/helper-function-name@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-function-name@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e"
@@ -58,6 +83,13 @@
     "@babel/template" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/helper-get-function-arity@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-get-function-arity@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
@@ -65,12 +97,24 @@
   dependencies:
     "@babel/types" "^7.7.4"
 
+"@babel/helper-split-export-declaration@^7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
+  integrity sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
+  dependencies:
+    "@babel/types" "^7.11.0"
+
 "@babel/helper-split-export-declaration@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8"
   integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helpers@^7.7.4":
   version "7.7.4"
@@ -90,6 +134,20 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.7.0":
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.4.tgz#6fa1a118b8b0d80d0267b719213dc947e88cc0ca"
+  integrity sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==
+
 "@babel/parser@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.4.tgz#75ab2d7110c2cf2fa949959afb05fa346d2231bb"
@@ -100,6 +158,15 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.7.tgz#1b886595419cf92d811316d5b715a53ff38b4937"
   integrity sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==
 
+"@babel/template@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -108,6 +175,21 @@
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.7.4"
     "@babel/types" "^7.7.4"
+
+"@babel/traverse@^7.7.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.0.tgz#9b996ce1b98f53f7c3e4175115605d56ed07dd24"
+  integrity sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.0"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.11.0"
+    "@babel/types" "^7.11.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
 
 "@babel/traverse@^7.7.4":
   version "7.7.4"
@@ -123,6 +205,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
+
+"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.7.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
+  integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.7.4":
   version "7.7.4"
@@ -336,15 +427,6 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-array.prototype.flatmap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
-  integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -359,6 +441,18 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+
+babel-eslint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -837,10 +931,18 @@ eslint-config-standard@14.1.1:
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz#830a8e44e7aef7de67464979ad06b406026c56ea"
   integrity sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==
 
-eslint-import-resolver-node@^0.3.2, eslint-import-resolver-node@^0.3.3:
+eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
   integrity sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.13.1"
+
+eslint-import-resolver-node@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
   dependencies:
     debug "^2.6.9"
     resolve "^1.13.1"
@@ -862,9 +964,9 @@ eslint-plugin-es@^2.0.0:
     regexpp "^3.0.0"
 
 eslint-plugin-es@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz#98cb1bc8ab0aa807977855e11ad9d1c9422d014b"
-  integrity sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
@@ -934,23 +1036,6 @@ eslint-plugin-promise@4.2.1, eslint-plugin-promise@~4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
   integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
-eslint-plugin-react@7.20.6:
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz#4d7845311a93c463493ccfa0a19c9c5d0fd69f60"
-  integrity sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==
-  dependencies:
-    array-includes "^3.1.1"
-    array.prototype.flatmap "^1.2.3"
-    doctrine "^2.1.0"
-    has "^1.0.3"
-    jsx-ast-utils "^2.4.1"
-    object.entries "^1.1.2"
-    object.fromentries "^2.0.2"
-    object.values "^1.1.1"
-    prop-types "^15.7.2"
-    resolve "^1.17.0"
-    string.prototype.matchall "^4.0.2"
-
 eslint-plugin-react@~7.14.2:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"
@@ -993,7 +1078,7 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -1482,7 +1567,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1515,15 +1600,6 @@ inquirer@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
-
-internal-slot@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.2.tgz#9c2e9fb3cd8e5e4256c6f45fe310067fcfa378a3"
-  integrity sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==
-  dependencies:
-    es-abstract "^1.17.0-next.1"
-    has "^1.0.3"
-    side-channel "^1.0.2"
 
 interpret@^1.0.0:
   version "1.2.0"
@@ -1778,7 +1854,7 @@ json@9.0.6:
   resolved "https://registry.yarnpkg.com/json/-/json-9.0.6.tgz#7972c2a5a48a42678db2730c7c2c4ee6e4e24585"
   integrity sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=
 
-jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.4.1:
+jsx-ast-utils@^2.1.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"
   integrity sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==
@@ -2096,7 +2172,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.1.0, object.entries@^1.1.2:
+object.entries@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
   integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
@@ -2105,7 +2181,7 @@ object.entries@^1.1.0, object.entries@^1.1.2:
     es-abstract "^1.17.5"
     has "^1.0.3"
 
-object.fromentries@^2.0.0, object.fromentries@^2.0.2:
+object.fromentries@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.2.tgz#4a09c9b9bb3843dd0f89acdb517a794d4f355ac9"
   integrity sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==
@@ -2546,7 +2622,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
+regexp.prototype.flags@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
   integrity sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==
@@ -2603,7 +2679,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@~1.17.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@~1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -2725,14 +2801,6 @@ shelljs@^0.8.0:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-side-channel@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"
-  integrity sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==
-  dependencies:
-    es-abstract "^1.17.0-next.1"
-    object-inspect "^1.7.0"
 
 signal-exit@^3.0.2:
   version "3.0.2"
@@ -2879,18 +2947,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string.prototype.matchall@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
-  integrity sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0"
-    has-symbols "^1.0.1"
-    internal-slot "^1.0.2"
-    regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.2"
 
 string.prototype.trim@~1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,7 +1538,7 @@ html-tokenize@^2.0.1:
     readable-stream "~1.0.27-1"
     through2 "~0.4.1"
 
-htmlclean@3.0.8:
+htmlclean@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/htmlclean/-/htmlclean-3.0.8.tgz#cea451cf5399d4018386a57129489f2d630e62b0"
   integrity sha1-zqRRz1OZ1AGDhqVxKUifLWMOYrA=


### PR DESCRIPTION
* use es6 features (e.g., classes, arrow functions)
* bump minimum node version to 12.x
* prepare to migrate to scoped package

-----
[View rendered README.md](https://github.com/gofunky/trumpet/blob/refactor/README.md)